### PR TITLE
Voiding reconciliation via mismatch when order refund amount changes + E2E coverage

### DIFF
--- a/REFUND_TRACKING_DESIGN.md
+++ b/REFUND_TRACKING_DESIGN.md
@@ -541,6 +541,11 @@ Accounting is achieved when values across returns, courier payments, and write-o
 
 ## Post‑Reconciliation Changes: Voiding by Mismatch (Order Refund Amount Changes)
 
+### Summary
+- Preserve prior reconciliations; do not mutate or delete history
+- Create an OTHERS delta RefundDetail for any change in buyerRefundAmount (positive or negative)
+- Recompute the order snapshot; order becomes non‑fully‑accounted until the delta is reconciled
+
 When an order's `buyerRefundAmount` changes after the order has already been fully reconciled, the system must effectively void the order-level fully-accounted state. We do not delete or mutate historical reconciliation rows. Instead, we re-introduce a mismatch so the order transitions back to a non-fully-accounted state until new reconciliation actions are taken.
 
 ### Behavior

--- a/packages/backend/tests/e2e/epsilon_small_delta_does_not_void_full_accounting.test.ts
+++ b/packages/backend/tests/e2e/epsilon_small_delta_does_not_void_full_accounting.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { api } from '../helpers/http';
+import { buildOrdersExcel, buildOrderRow } from '../helpers/excel';
+import FormData from 'form-data';
+import { deleteOrderCascade } from '../helpers/cleanup';
+import { expectAmountsClose } from '../helpers/assertions';
+
+const unique = () => Math.random().toString(36).slice(2);
+
+/**
+ * Scenario: Very small increase (< epsilon) in buyerRefundAmount should not void fully-accounted state
+ * - Start at 500, reconcile MATCHED 500
+ * - Increase to 500.005 (delta below 0.01 epsilon)
+ * - Assert accountedRefundAmount ~= buyerRefundAmount (still effectively fully accounted)
+ */
+
+describe('Small delta (< epsilon) does not void fully-accounted state', () => {
+  const orderId = `RECONVOID_EPS_${unique()}`;
+  let refundId: string;
+
+  beforeAll(async () => {
+    const buf = buildOrdersExcel([
+      buildOrderRow({ orderId, buyerRefundAmount: 500, items: [] }),
+    ]);
+    const fd = new FormData();
+    fd.append('file', buf, { filename: 'orders.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const res = await api.post('/orders/upload-excel', fd, { headers: fd.getHeaders() });
+    expect(res.data.success).toBe(true);
+  });
+
+  afterAll(async () => {
+    await deleteOrderCascade(orderId);
+  });
+
+  it('creates initial refund and reconciles to matched', async () => {
+    const res = await api.post('/refunds/initiate', {
+      orderId,
+      refundAmount: 500,
+      refundType: 'PLATFORM_FEES',
+      status: 'INITIATED',
+      accountingStatus: 'UNACCOUNTED',
+    });
+    expect(res.status).toBe(201);
+    refundId = res.data.refund.id;
+
+    const recon = await api.post(`/reconciliation/${refundId}/reconcile`, {
+      expectedValue: 500,
+      actualValue: 500,
+      status: 'MATCHED',
+      notes: 'Initial match',
+    });
+    expect(recon.status).toBe(201);
+
+    const order = await api.get(`/orders/${orderId}`);
+    const accounted = Number(order.data.order?.refundAccount?.accountedRefundAmount || 0);
+    const expected = Number(order.data.order?.buyerRefundAmount || 0);
+    expectAmountsClose(accounted, expected);
+  });
+
+  it('increases buyerRefundAmount by 0.005 and remains effectively fully accounted', async () => {
+    const buf = buildOrdersExcel([
+      buildOrderRow({ orderId, buyerRefundAmount: 500.005, items: [] }),
+    ]);
+    const fd = new FormData();
+    fd.append('file', buf, { filename: 'orders.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const res = await api.post('/orders/upload-excel', fd, { headers: fd.getHeaders() });
+    expect(res.data.success).toBe(true);
+
+    const order = await api.get(`/orders/${orderId}`);
+    const accounted = Number(order.data.order?.refundAccount?.accountedRefundAmount || 0);
+    const expected = Number(order.data.order?.buyerRefundAmount || 0);
+    // Difference is 0.005, below epsilon 0.01
+    expectAmountsClose(accounted, expected);
+  });
+}); 

--- a/packages/backend/tests/e2e/void_reconciliation_on_order_amount_change.test.ts
+++ b/packages/backend/tests/e2e/void_reconciliation_on_order_amount_change.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { api } from '../helpers/http';
+import { buildOrdersExcel, buildOrderRow } from '../helpers/excel';
+import FormData from 'form-data';
+import { deleteOrderCascade } from '../helpers/cleanup';
+
+const unique = () => Math.random().toString(36).slice(2);
+
+/**
+ * Scenario: Order fully reconciled, then buyerRefundAmount changes → previous fully-accounted state is voided
+ * - Create order via Excel (buyerRefundAmount = 500)
+ * - Create RefundDetail type PLATFORM_FEES (500)
+ * - Reconcile as MATCHED with actualValue 500
+ * - Verify accountedRefundAmount >= 500 and status is effectively FULLY_ACCOUNTED (by equality check)
+ * - Upload Excel with increased buyerRefundAmount = 800
+ * - System creates OTHERS RefundDetail for +300 (UNACCOUNTED)
+ * - Snapshot recompute keeps accountedRefundAmount at ~500, but expected is now 800
+ * - Assert order not fully accounted anymore (accountedRefundAmount < buyerRefundAmount) and delta detail exists
+ */
+
+describe('Voids fully-accounted state when order refund total changes', () => {
+  const orderId = `VOID_${unique()}`;
+  let refundId: string;
+
+  beforeAll(async () => {
+    // Initial order upload: 500
+    const buf = buildOrdersExcel([
+      buildOrderRow({ orderId, buyerRefundAmount: 500, items: [] }),
+    ]);
+    const fd = new FormData();
+    fd.append('file', buf, { filename: 'orders.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const res = await api.post('/orders/upload-excel', fd, { headers: fd.getHeaders() });
+    expect(res.data.success).toBe(true);
+  });
+
+  afterAll(async () => {
+    await deleteOrderCascade(orderId);
+  });
+
+  it('creates initial refund and reconciles to matched', async () => {
+    // Create a refund detail equal to total
+    const res = await api.post('/refunds/initiate', {
+      orderId,
+      refundAmount: 500,
+      refundType: 'PLATFORM_FEES',
+      status: 'INITIATED',
+      accountingStatus: 'UNACCOUNTED',
+    });
+    expect(res.status).toBe(201);
+    refundId = res.data.refund.id;
+
+    const recon = await api.post(`/reconciliation/${refundId}/reconcile`, {
+      expectedValue: 500,
+      actualValue: 500,
+      status: 'MATCHED',
+      notes: 'Initial match',
+    });
+    expect(recon.status).toBe(201);
+
+    const order = await api.get(`/orders/${orderId}`);
+    const accounted = Number(order.data.order?.refundAccount?.accountedRefundAmount || 0);
+    const expected = Number(order.data.order?.buyerRefundAmount || 0);
+    expect(accounted).toBeGreaterThanOrEqual(500);
+    expect(Math.abs(accounted - expected)).toBeLessThan(0.01);
+  });
+
+  it('increases order buyerRefundAmount via Excel and voids fully-accounted state', async () => {
+    // Increase order total to 800
+    const buf = buildOrdersExcel([
+      buildOrderRow({ orderId, buyerRefundAmount: 800, items: [] }),
+    ]);
+    const fd = new FormData();
+    fd.append('file', buf, { filename: 'orders.xlsx', contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const res = await api.post('/orders/upload-excel', fd, { headers: fd.getHeaders() });
+    expect(res.data.success).toBe(true);
+
+    // After upload, snapshot recompute should reflect mismatch
+    const order = await api.get(`/orders/${orderId}`);
+    expect(order.data.success).toBe(true);
+    const accounted = Number(order.data.order?.refundAccount?.accountedRefundAmount || 0);
+    const expected = Number(order.data.order?.buyerRefundAmount || 0);
+
+    // accounted should still be ~500 (no reconciliation yet for +300 detail)
+    expect(accounted).toBeGreaterThanOrEqual(500);
+    expect(expected).toBe(800);
+    expect(Math.abs(accounted - expected)).toBeGreaterThan(0.01);
+  });
+}); 

--- a/packages/backend/tests/helpers/assertions.ts
+++ b/packages/backend/tests/helpers/assertions.ts
@@ -1,0 +1,11 @@
+import { expect } from 'vitest';
+
+export const DEFAULT_EPSILON = 0.01;
+
+export function expectAmountsClose(accounted: number, expected: number, epsilon: number = DEFAULT_EPSILON): void {
+  expect(Math.abs(accounted - expected)).toBeLessThan(epsilon);
+}
+
+export function expectAmountsNotClose(accounted: number, expected: number, epsilon: number = DEFAULT_EPSILON): void {
+  expect(Math.abs(accounted - expected)).toBeGreaterThan(epsilon);
+} 


### PR DESCRIPTION
Docs: Add design section on post‑reconciliation changes—preserve reconciliation history, create OTHERS delta RefundDetail, recompute snapshot, and derive non‑fully‑accounted status until reconciled.
Test: New E2E verifies increasing buyerRefundAmount (500 → 800) introduces a mismatch (accountedRefundAmount ~500 < 800) until the delta is reconciled.
Impact: No runtime changes; leverages existing endpoints and snapshot logic.